### PR TITLE
SSR : Delay changes on window

### DIFF
--- a/lib/providers/scriptLoader.ts
+++ b/lib/providers/scriptLoader.ts
@@ -12,11 +12,13 @@ export class ScriptLoaderConfig {
   public ak: string = ''
 }
 
-window._scriptLoadState = {}
-window._loadingCallbacks = {}
-
 @Injectable()
 export class ScriptLoader {
+  constructor()  {
+    window._scriptLoadState = {}
+    window._loadingCallbacks = {} 
+  }
+  
   public load(url: string | ScriptType, isMain: boolean = false, cb: () => void): void {
     const scriptKey = isString(url) ? url : url['key']
     const scriptUrls = isString(url) ? [url] : url['scripts']


### PR DESCRIPTION
### Context :
 
While doing SSR, window is not defined when the file is imported. Immediate changes on window cause an error, stopping the module initialization.

### Fix :

*issue #100*
Some inits on window are moved to ScriptLoader constructor.
