### PR TITLE
fix(#111): allow angular 9 and 10 versions in peerDependencies

### DIFF
--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angular2-baidu-map",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "peerDependencies": {
-    "@angular/common": "^8.2.13",
-    "@angular/core": "^8.2.13"
+    "@angular/common": ">=8.0.0",
+    "@angular/core": ">=8.0.0"
   }
 }


### PR DESCRIPTION
This should avoid peer dependency warning when using angular 9